### PR TITLE
Fix #7: Fix to work with newer versions of Svelte

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dopry/svelte-oidc",
-	"version": "0.3.1",
+	"version": "0.4.0",
 	"repository": "https://github.com/dopry/svelte-oidc",
 	"description": "Svelte OIDC Component Library",
 	"keywords": [


### PR DESCRIPTION
Removed usage of getContext and setContext, the context keys are not exported by components.module.js. It's therefor unlikely that the contexts are directly used outside of the component, so I decided to remove them.

Removed unnecessary promise for userManager and fixed so the user is loaded from local store if it exists.

I've tested this with the application I'm writing and it did not require any changes on the implementation side.