### PR TITLE
Allow passing through extra options to oidc-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ const metadata = {
  redirect_uri="https://darrelopry.com/svelte-oidc/"
  post_logout_redirect_uri="https://darrelopry.com/svelte-oidc/"
  metadata={metadata}
+ extraOptions={{
+   mergeClaims: true,
+   resource: "some_identifier",
+ }}
  >
 
   <LoginButton>Login</LoginButton>
@@ -113,6 +117,7 @@ the migration hard.
   * redirect_uri -  default: window.location.href
   * post_logout_redirect_uri - override the default url that OIDC will redirect to after logout. default: window.location.href
   * metadata - set default metadata or metadata missing from authority.
+  * extraOptions - An object of extra options that will be passed to the underlying OpenID Connect client. Valid values are available [here](https://github.com/IdentityModel/oidc-client-js/wiki#other-optional-settings).
 
 * LoginButton - log out the current context
 

--- a/src/components/OidcContext.svelte
+++ b/src/components/OidcContext.svelte
@@ -104,7 +104,7 @@
 	export let client_id;
 	export let redirect_uri;
 	export let post_logout_redirect_uri;
-	export let extra_options = {};
+	export let extraOptions = {};
 
 	export let scope = 'openid profile email';
 
@@ -119,7 +119,7 @@
 		response_type: 'code',
 		scope,
 		automaticSilentRenew: true,
-		...extra_options,
+		...extraOptions,
 	};
 
 	const userManager = new oidcClient.UserManager(settings);

--- a/src/components/OidcContext.svelte
+++ b/src/components/OidcContext.svelte
@@ -104,6 +104,7 @@
 	export let client_id;
 	export let redirect_uri;
 	export let post_logout_redirect_uri;
+	export let extra_options = {};
 
 	export let scope = 'openid profile email';
 
@@ -118,6 +119,7 @@
 		response_type: 'code',
 		scope,
 		automaticSilentRenew: true,
+		...extra_options,
 	};
 
 	const userManager = new oidcClient.UserManager(settings);


### PR DESCRIPTION
Currently the oidc-client options are restricted to those implemented by this package.

This change allows the user to specify extra parameters not already implemented here (`extraQueryParams` in my case)