### PR TITLE
feat: prompt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ tooling.
   Attributes:
   * preserve_route - tell the callback handler to return to the current url after login. default: true
   * callback_url - override the context callback_url
+  * prompt - optional OIDC `prompt` parameter controlling whether and how the user is prompted to authenticate or authorize.  If omitted (`undefined`), the identity provider's default behavior is used. Supported values are:
+    * 'login'          — force the user to re-authenticate.
+    * 'create'         — request creation of a new user account (if supported).
+    * 'none'           — do not display any user interaction (fail if interaction is required).
+    * 'consent'        — prompt the user for consent.
+    * 'select_account' — prompt the user to select an account.
 
 * LogoutButton - log in the current context
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -41,6 +41,7 @@ const addClass = () => {
 >
   <div class="row">
     <div class="col s12 m6">
+      <LoginButton styles="{styles}" classes="{classes}" prompt="create">Register</LoginButton>
       <LoginButton styles="{styles}" classes="{classes}">Login</LoginButton>
       <LogoutButton styles="{styles}" classes="{classes}">Logout</LogoutButton>
       <RefreshTokenButton styles="{styles}" classes="{classes}">refreshToken</RefreshTokenButton>

--- a/src/lib/LoginButton.svelte
+++ b/src/lib/LoginButton.svelte
@@ -11,6 +11,7 @@
     export let preserveRoute
     export let classes = ''
     export let styles = ''
+    export let prompt
 </script>
 
-<button class="btn {classes}" style="{styles}" on:click|preventDefault='{() => login(oidcPromise, preserveRoute, callback_url) }'><slot></slot></button>
+<button class="btn {classes}" style="{styles}" on:click|preventDefault='{() => login(oidcPromise, preserveRoute, callback_url, prompt) }'><slot></slot></button>

--- a/src/lib/OidcContext.svelte
+++ b/src/lib/OidcContext.svelte
@@ -3,6 +3,7 @@
 	import { onDestroy, onMount, setContext } from 'svelte';
 	import { writable } from 'svelte/store';
 
+	export type Prompt = 'login' | 'create' | 'none' | 'consent' | 'select_account' | undefined;
 	/**
 	 * Stores
 	 */
@@ -34,8 +35,8 @@
 	export async function refreshToken(oidcPromise: Promise<UserManager>): Promise<boolean> {
 		try {
 		  const oidc = await oidcPromise
-		  await oidc.signinSilent();
-		  return true;
+			await oidc.signinSilent();
+			return true;
 		}
 		catch (e) {
 			// set error state for reactive handling
@@ -50,8 +51,10 @@
 	 * @param oidcPromise
 	 * @param preserveRoute - store current location so callback handler will navigate back to it.
 	 * @param callback_url - explicit path to use for the callback.
+	 * @param prompt - optional OIDC prompt value controlling whether the user is prompted to log in,
+	 *                 create a new account, or reuse an existing session, depending on the identity provider.
 	 */
-	export async function login(oidcPromise: Promise<UserManager>, preserveRoute = true, callback_url?: string): Promise<void> {
+	export async function login(oidcPromise: Promise<UserManager>, preserveRoute = true, callback_url?: string, prompt?: Prompt): Promise<void> {
 		const oidc = await oidcPromise;
 		const redirect_uri = callback_url || window.location.href;
 
@@ -61,9 +64,9 @@
 			? {
 					pathname: window.location.pathname,
 					search: window.location.search,
-			  }
+				}
 			: {};
-		await oidc.signinRedirect({ redirect_uri, state });
+		await oidc.signinRedirect({ redirect_uri, state, prompt });
 	}
 
 	/**
@@ -128,35 +131,35 @@
 		userInfo.set(user.profile);
 	});
 
-	userManager.events.addUserUnloaded(function() {
+	userManager.events.addUserUnloaded(function () {
 		isAuthenticated.set(false);
 		idToken.set('');
 		accessToken.set('');
 		userInfo.set({});
-    });
+	});
 
-	userManager.events.addSilentRenewError(function(e) {
+	userManager.events.addSilentRenewError(function (e) {
 		authError.set(`SilentRenewError: ${e.message}`);
-    });
+	});
 
 
-    // does userManager needs to be wrapped in a promise? or is this a left over to maintain
+	// does userManager needs to be wrapped in a promise? or is this a left over to maintain
 	// symmetry with the @dopry/svelte-auth0 auth0 implementation
 	let oidcPromise = Promise.resolve(userManager);
-    setContext(OIDC_CONTEXT_CLIENT_PROMISE, oidcPromise);
+	setContext(OIDC_CONTEXT_CLIENT_PROMISE, oidcPromise);
 
-    // Not all browsers support this, please program defensively!
-    const params = new URLSearchParams(window.location.search);
+	// Not all browsers support this, please program defensively!
+	const params = new URLSearchParams(window.location.search);
 
 	// Use 'error' and 'code' to test if the component is being executed as a part of a login callback. If we're not
 	// running in a login callback, and the user isn't logged in, see if we can capture their existing session.
-    if (!params.has('error') && !params.has('code') && !$isAuthenticated) {
-        refreshToken(oidcPromise);
-    }
+	if (!params.has('error') && !params.has('code') && !$isAuthenticated) {
+		refreshToken(oidcPromise);
+	}
 
 	async function handleOnMount() {
 		// on run onMount after oidc
-        const oidc = await oidcPromise;
+		const oidc = await oidcPromise;
 
 		// Check if something went wrong during login redirect
 		// and extract the error message


### PR DESCRIPTION
add a register button and method which uses prompt=create to send a user directly to the registration page for IDPs that support it.